### PR TITLE
Eslam.salem/lfi revert to default

### DIFF
--- a/build/recommended.json
+++ b/build/recommended.json
@@ -229,9 +229,7 @@
           "operator": "match_regex"
         }
       ],
-      "transformers": [
-        "normalizePath"
-      ]
+      "transformers": []
     },
     {
       "id": "crs-930-110",
@@ -262,8 +260,7 @@
         }
       ],
       "transformers": [
-        "removeNulls",
-        "normalizePath"
+        "removeNulls"
       ]
     },
     {
@@ -1404,8 +1401,7 @@
         }
       ],
       "transformers": [
-        "lowercase",
-        "normalizePath"
+        "lowercase"
       ]
     },
     {

--- a/build/recommended.yaml
+++ b/build/recommended.yaml
@@ -139,8 +139,7 @@ rules:
           options:
             min_length: 4
         operator: match_regex
-    transformers:
-      - normalizePath
+    transformers: []
   - id: crs-930-110
     name: Simple Path Traversal Attack (/../)
     tags:
@@ -159,7 +158,6 @@ rules:
         operator: match_regex
     transformers:
       - removeNulls
-      - normalizePath
   - id: crs-930-120
     name: OS File Access Attempt
     tags:
@@ -1282,7 +1280,6 @@ rules:
         operator: phrase_match
     transformers:
       - lowercase
-      - normalizePath
   - id: crs-931-110
     name: 'RFI: Common RFI Vulnerable Parameter Name used w/ URL Payload'
     tags:

--- a/build/risky.json
+++ b/build/risky.json
@@ -1475,7 +1475,7 @@
     },
     {
       "id": "crs-942-220",
-      "name": "Looking for integer overflow attacks, these are taken from skipfish, except 2.2.2250738585072011e-308 is the \\\"magic number\\\" crash",
+      "name": "Looking for integer overflow attacks",
       "tags": {
         "type": "sql_injection",
         "crs_id": "942220",

--- a/build/risky.yaml
+++ b/build/risky.yaml
@@ -1352,9 +1352,7 @@ rules:
         operator: match_regex
     transformers: []
   - id: crs-942-220
-    name: >-
-      Looking for integer overflow attacks, these are taken from skipfish,
-      except 2.2.2250738585072011e-308 is the \"magic number\" crash
+    name: Looking for integer overflow attacks
     tags:
       type: sql_injection
       crs_id: '942220'

--- a/rules/recommended/crs-930-100.yaml
+++ b/rules/recommended/crs-930-100.yaml
@@ -14,5 +14,4 @@ conditions:
       options:
         min_length: 4
     operator: match_regex
-transformers:
-  - normalizePath
+transformers: []

--- a/rules/recommended/crs-930-110.yaml
+++ b/rules/recommended/crs-930-110.yaml
@@ -16,4 +16,3 @@ conditions:
     operator: match_regex
 transformers:
   - removeNulls
-  - normalizePath

--- a/rules/recommended/crs-930-120.yaml
+++ b/rules/recommended/crs-930-120.yaml
@@ -1120,4 +1120,3 @@ conditions:
     operator: phrase_match
 transformers:
   - lowercase
-  - normalizePath

--- a/rules/risky/crs-930-121.yaml
+++ b/rules/risky/crs-930-121.yaml
@@ -1205,4 +1205,3 @@ conditions:
     operator: phrase_match
 transformers:
   - lowercase
-  - normalizePath


### PR DESCRIPTION
### What does this PR do?

Removing the normalizePath from LFI rules because some libraries didn't handle it correctly. 

