### PR TITLE
Remove a normalization transformer from a rule that doesn't need it

### DIFF
--- a/build/recommended.json
+++ b/build/recommended.json
@@ -262,8 +262,7 @@
         }
       ],
       "transformers": [
-        "removeNulls",
-        "normalizePath"
+        "removeNulls"
       ]
     },
     {

--- a/build/recommended.yaml
+++ b/build/recommended.yaml
@@ -159,7 +159,6 @@ rules:
         operator: match_regex
     transformers:
       - removeNulls
-      - normalizePath
   - id: crs-930-120
     name: OS File Access Attempt
     tags:

--- a/rules/recommended/crs-930-110.yaml
+++ b/rules/recommended/crs-930-110.yaml
@@ -16,4 +16,3 @@ conditions:
     operator: match_regex
 transformers:
   - removeNulls
-  - normalizePath


### PR DESCRIPTION
### What does this PR do?
Remove the `normalizePath` transformer from a rule looking for directory transversal (which this transformer removes)

### Motivation
<!-- What inspired you to submit this pull request? Add link to the initial issue -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->