### PR TITLE
Automatically deploy released event rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+stages:
+ - deploy
+
+deploy:
+  stage: deploy
+  tags: ["runner:main"]
+  only:
+   - main
+   - tags
+  trigger:
+    project: DataDog/dd-go
+    branch: prod
+  variables:
+    DYNAMIC_BUILD_RENDER_TARGET: //ci/pipelines/appsec:event_rules
+    APPSEC_EVENT_RULES_REF: $CI_COMMIT_REF_NAME


### PR DESCRIPTION
### What does this PR do?

This PR introduces a gitlab job to automatically trigger a downstream job after a release or a new change on the main branch.